### PR TITLE
added FileFilter option

### DIFF
--- a/TFS2010Interface/Helper Classes/Singleton.cs
+++ b/TFS2010Interface/Helper Classes/Singleton.cs
@@ -14,6 +14,7 @@ namespace chrisbjohnson.TFS2010Interface
         private string _tfsServer;
         private string _tfsWorkspace;
         private string _tfsPath;
+        private string _fileFilter;
 
         private Singleton()
         {
@@ -73,6 +74,24 @@ namespace chrisbjohnson.TFS2010Interface
                 if (value != _tfsPath)
                 {
                     _tfsPath = value;
+                    EventHandler handler = OptionsUpdatedEvent;
+                    if (handler != null)
+                    {
+                        handler(this, EventArgs.Empty);
+                    }
+                }
+            }
+
+        }
+
+        public string FileFilter
+        {
+            get { return _fileFilter; }
+            set
+            {
+                if (value != _fileFilter)
+                {
+                    _fileFilter = value;
                     EventHandler handler = OptionsUpdatedEvent;
                     if (handler != null)
                     {

--- a/TFS2010Interface/Helper Classes/ToolsOptions.cs
+++ b/TFS2010Interface/Helper Classes/ToolsOptions.cs
@@ -38,5 +38,11 @@ namespace chrisbjohnson.TFS2010Interface
             get { return _tfsPath; }
             set { _tfsPath = value; }
         }
+
+        [Category("General")]
+        [DisplayName("File Filter")]
+        [Description(@"Regex used to filter files. File paths matching this filter will be ignored. e.g. ""\\bin"" ignores bin folder.")]
+        public string FileFilter { get; set; }
+
     }
 }

--- a/TFS2010Interface/MVVM/MyControlViewModel.cs
+++ b/TFS2010Interface/MVVM/MyControlViewModel.cs
@@ -168,7 +168,7 @@ namespace chrisbjohnson.TFS2010Interface
 
             if (FileLoadingWorker.IsBusy)
                 return;
-            
+
             // Read all files and update filters
             FileLoadingWorker.RunWorkerAsync();
         }
@@ -183,8 +183,16 @@ namespace chrisbjohnson.TFS2010Interface
 
             List<string> localFiles = tfsController.GetLocalItems(currentPath);
 
+            string filter = Singleton.GetObject().FileFilter;
+            bool doFilter= !string.IsNullOrEmpty(filter);
+
             foreach (string file in localFiles)
             {
+                if (doFilter && Regex.IsMatch(file, filter))
+                {
+                    continue;
+                }
+
                 Files.Add(new TFSItemViewModel(file));
             }
 
@@ -235,8 +243,8 @@ namespace chrisbjohnson.TFS2010Interface
             string solutionDir = Common.GetSolutionDirectory();
 
             // Get all files that are checked out for the appropriate path based on the filter selected
-            List<string> checkedoutFiles = tfsController.GetFilesWithPendingChanges(SearchSolution && !string.IsNullOrEmpty(solutionDir) ? 
-                                                                                    solutionDir : 
+            List<string> checkedoutFiles = tfsController.GetFilesWithPendingChanges(SearchSolution && !string.IsNullOrEmpty(solutionDir) ?
+                                                                                    solutionDir :
                                                                                     tfsController.Workspace.Folders[0].LocalItem + Singleton.GetObject().TFSPath);
 
             // First get the read/write files
@@ -267,7 +275,7 @@ namespace chrisbjohnson.TFS2010Interface
             if (searchFilter == "")
                 SearchedFiles = new ObservableCollection<TFSItemViewModel>(FilteredFiles.OrderBy(p => p.Filename));
             else
-                SearchedFiles = new ObservableCollection<TFSItemViewModel>(FilteredFiles.Where(p => Regex.Match(p.Filepath, searchFilter,RegexOptions.IgnoreCase).Success).OrderBy(p => p.Filename));
+                SearchedFiles = new ObservableCollection<TFSItemViewModel>(FilteredFiles.Where(p => Regex.Match(p.Filepath, searchFilter, RegexOptions.IgnoreCase).Success).OrderBy(p => p.Filename));
 
             SyncCheckedoutItems();
         }

--- a/TFS2010Interface/TFS2010InterfacePackage.cs
+++ b/TFS2010Interface/TFS2010InterfacePackage.cs
@@ -145,6 +145,7 @@ namespace chrisbjohnson.TFS2010Interface
             singleton.TFSServer = options.TFSServer;
             singleton.TFSWorkspace = options.TFSWorkspace;
             singleton.TFSPath = options.TFSPath;
+            singleton.FileFilter = options.FileFilter;
         }
     }
 }

--- a/TFS2010Interface/source.extension.vsixmanifest
+++ b/TFS2010Interface/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="247cd7fe-e882-4bbd-ad48-a7be121a7c2d" Version="1.0" Language="en-US" Publisher="chrisbjohnson" />
+    <Identity Id="247cd7fe-e882-4bbd-ad48-a7be121a7c2d" Version="1.1" Language="en-US" Publisher="chrisbjohnson" />
     <DisplayName>TFS File Explorer</DisplayName>
     <Description xml:space="preserve">Allows access to TFS 2008 instance from Visual Studio 2013</Description>
     <License>MIT License.txt</License>


### PR DESCRIPTION
added FileFilter option to allow filtering list. any path that matches
the regex string will be ignored.
for example, you can ignore any files in the "\Dist" folder, since those are typically Read/Write, but we don't care about those.
